### PR TITLE
remove old versions of the suggest classifier.  fixes #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Steps for adding this to your existing hubot:
 export HUBOT_WATSON_NLC_URL=<API URL for Watson Natural Language Classifier>
 export HUBOT_WATSON_NLC_USERNAME=<Watson NLC Username>
 export HUBOT_WATSON_NLC_PASSWORD=<Watson NLC Password>
+export HUBOT_WATSON_NLC_SUGGEST_PREFIX=<Optional prefix to include in NLC classifier name>
 ```
 
 5. Start up your bot & off to the races!
@@ -58,6 +59,8 @@ export HUBOT_BLUEMIX_PASSWORD=<Password for the Bluemix use>
 2. Download the jquery.min.js library to the `lib` folder of this project.  This can be obtained from here: http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js
 3. Run `npm run update-config` to generate or update `data/services-data.json`.
 4. Review `data/services-data.json` file changes.  Load the doc page of added services to confirm quality of doc and what the service is called on the doc pages.  If services is referred to by names other than their doc_name attribute, then add those names to doc_name.
+  - Optional: Full manual training can be done by adding `class_text` array of strings in `nlc_class_info` objects.
+  - Optional: To still using crawler generated data, but also include partial manual training data add `additional_class_text` instead of `class_text`.
 5. Use crawler to produce training data:
   - `npm run crawler -- --key=<YOUR_ALCHEMY_API_KEY>`
 6. Review output from crawler and copy the generated csv file into the data directory using the next version number of the `data/hubot-service-suggest` .csv file.

--- a/src/lib/env.js
+++ b/src/lib/env.js
@@ -11,6 +11,7 @@ const nlc = {
   url: process.env.HUBOT_WATSON_NLC_URL,
   username: process.env.HUBOT_WATSON_NLC_USERNAME,
   password: process.env.HUBOT_WATSON_NLC_PASSWORD,
+  prefix: process.env.HUBOT_WATSON_NLC_SUGGEST_PREFIX
 };
 
 if (!nlc.url) {

--- a/test/resources/mock.classifierAvailable.json
+++ b/test/resources/mock.classifierAvailable.json
@@ -3,7 +3,7 @@
   "name": "hubot-service-suggest-v2",
   "language": "en",
   "created": "2016-06-29T19:09:59.000Z",
-  "url": "https://testClassifierUrl",
+  "url": "https://watson-nlc-api/v1/classifiers/cd02b5x110-nlc-5103",
   "status": "Available",
   "status_description": "The classifier instance is now available and is ready to take classifier requests."
 }

--- a/test/resources/mock.classifierList.json
+++ b/test/resources/mock.classifierList.json
@@ -1,8 +1,17 @@
 {
   "classifiers": [
     {
+      "classifier_id": "cd02b5x110-nlc-old",
+      "note": "This an old version that should be deleted when service suggest starts up",
+      "url": "https://watson-nlc-api/v1/classifiers/cd02b5x110-nlc-old",
+      "name": "hubot-service-suggest-v1",
+      "language": "en",
+      "created": "2016-06-29T15:24:48.919Z"
+    },
+    {
       "classifier_id": "cd02b5x110-nlc-5103",
-      "url": "https://testClassifierUrl",
+      "note": "This is the current version whose ID will be used for other operations",
+      "url": "https://watson-nlc-api/v1/classifiers/cd02b5x110-nlc-5103",
       "name": "hubot-service-suggest-v2",
       "language": "en",
       "created": "2016-06-29T15:24:48.919Z"

--- a/test/service.suggest.mock.js
+++ b/test/service.suggest.mock.js
@@ -52,5 +52,11 @@ module.exports = {
       text: 'error'
     })
     .reply(500, 'Some 500 error message from the NLC service');
+
+    // Mock route for when the old classifier is deleted
+    nlcScope.delete('/v1/classifiers/cd02b5x110-nlc-old').reply(200, function() {
+      return {};
+    });
+
   }
 };


### PR DESCRIPTION
@reicruz we'll now cleanup old versions of the classifier when version # in .csv file name is increased.  The nlcManager.trainIfNeeded() call will initiate the training of the newer version.

I also added a prefix env var, in the off chance that multiple instances of the bot are running at different version levels and pointing to the same NLC instance.  That way one could use this prefix to prevent one instance from deleting the classifier used by the other instance.
